### PR TITLE
fix(fourier): "cannot import name 'imresize'"

### DIFF
--- a/pybalu/feature_extraction/fourier.py
+++ b/pybalu/feature_extraction/fourier.py
@@ -1,7 +1,7 @@
 __all__ = ['fourier_features', 'FourierExtractor']
 
 import numpy as np
-from scipy.misc import imresize
+from skimage.transform import resize
 import itertools as it
 
 from pybalu.base import FeatureExtractor
@@ -89,14 +89,14 @@ Fourier Ang (2, 2) [rad]:  0.01847
     if show:
         print('--- extracting Fourier features...')
 
-    img_resize = imresize(I, (vresize, hresize), interp='bicubic', mode='F')
+    img_resize = resize(I, (vresize, hresize), interp='bicubic', mode='F')
     img_fourier = np.fft.fft2(img_resize)
     img_abs = np.abs(img_fourier)
     img_angle = np.angle(img_fourier)
 
-    F = imresize(img_abs[:v_half, :h_half],
+    F = resize(img_abs[:v_half, :h_half],
                  (vfreq, hfreq), interp='bicubic', mode='F')
-    A = imresize(img_angle[:v_half, :h_half],
+    A = resize(img_angle[:v_half, :h_half],
                  (vfreq, hfreq), interp='bicubic', mode='F')
 
     features = np.hstack([F.ravel(), A.ravel()]).astype(float)

--- a/pybalu/feature_extraction/fourier.py
+++ b/pybalu/feature_extraction/fourier.py
@@ -33,7 +33,7 @@ hfreq: int, optional
 show : bool, optional
     Wether to print or not messages during execution
 labels : bool, optional
-    Wether to return a second array that contains the label of each value. 
+    Wether to return a second array that contains the label of each value.
 
 Returns
 -------
@@ -89,15 +89,13 @@ Fourier Ang (2, 2) [rad]:  0.01847
     if show:
         print('--- extracting Fourier features...')
 
-    img_resize = resize(I, (vresize, hresize), interp='bicubic', mode='F')
+    img_resize = resize(I, (vresize, hresize))
     img_fourier = np.fft.fft2(img_resize)
     img_abs = np.abs(img_fourier)
     img_angle = np.angle(img_fourier)
 
-    F = resize(img_abs[:v_half, :h_half],
-                 (vfreq, hfreq), interp='bicubic', mode='F')
-    A = resize(img_angle[:v_half, :h_half],
-                 (vfreq, hfreq), interp='bicubic', mode='F')
+    F = resize(img_abs[:v_half, :h_half], (vfreq, hfreq))
+    A = resize(img_angle[:v_half, :h_half], (vfreq, hfreq))
 
     features = np.hstack([F.ravel(), A.ravel()]).astype(float)
     if labels:


### PR DESCRIPTION
#### Fix error: "cannot import name 'imresize'"  from `feature_extraction/fourier.py`.

---

Since scipy 1.3.0rc1 `imresize` has been removed. This uses the [equivalent](https://scikit-image.org/docs/stable/auto_examples/transform/plot_rescale.html) `skimage.transform.resize` method.

This solution was based in favor of the `rgb2hcm.py` module which uses this same method.